### PR TITLE
KH-4325 互換性のあるランタイムのバージョンを nodejs14, nodejs20 に変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-nodejs12.x
+FROM amazon/aws-lambda-nodejs:22
 
 ENV ROOT_DIR /usr/local/pdfkit
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,5 +15,5 @@ layers:
     licenseInfo: MIT
     retain: true
     compatibleRuntimes:
-      - nodejs10.x
-      - nodejs12.x
+      - nodejs14.x
+      - nodejs20.x


### PR DESCRIPTION
### 対応する issue

https://beartail.atlassian.net/browse/KH-4325

### 概要

 互換性のあるランタイムのバージョンの指定を次の内容に変更しました。

- nodejs14 - 現行の関数が利用しているランタイムのバージョン
- nodejs20 - 予定しているバージョンアップ後の関数のランタイムのバージョン